### PR TITLE
Add support for validator functions

### DIFF
--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -304,6 +304,21 @@ def test_function():
 
     assert {"type": "array", "items": {"type": "string"}} == convert(validator_list)
 
+    def validator_set_int(value: set[int]):
+        return value
+
+    assert {"type": "array", "items": {"type": "integer"}} == convert(validator_set_int)
+
+    def validator_set_any(value: set[Any]):
+        return value
+
+    assert {"type": "array", "items": {"type": "string"}} == convert(validator_set_any)
+
+    def validator_set(value: set):
+        return value
+
+    assert {"type": "array", "items": {"type": "string"}} == convert(validator_set)
+
     def validator_dict(value: dict):
         return value
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 import voluptuous as vol
-from typing import Any
+from typing import Any, TypeVar
 
 from voluptuous_openapi import UNSUPPORTED, convert
 
@@ -273,3 +273,14 @@ def test_function():
     assert {"anyOf": [{"type": "number"}, {"type": "integer"}]} == convert(
         vol.Schema(validator_union)
     )
+
+    _T = TypeVar("_T")
+
+    def validator_nullable_2(value: _T | None):
+        return value
+
+    assert {
+        "type": "object",
+        "properties": {"var": {"type": "array", "items": {"type": "string"}}},
+        "required": [],
+    } == convert(vol.Schema({"var": vol.All(validator_nullable_2, [validator_any])}))

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -209,6 +209,8 @@ def test_list():
         "items": {"type": "string"},
     } == convert(vol.Schema([str]))
 
+    assert {"type": "array", "items": {"type": "string"}} == convert(vol.Schema(list))
+
 
 def test_any_of():
     assert {"anyOf": [{"type": "number"}, {"type": "integer"}]} == convert(
@@ -284,3 +286,32 @@ def test_function():
         "properties": {"var": {"type": "array", "items": {"type": "string"}}},
         "required": [],
     } == convert(vol.Schema({"var": vol.All(validator_nullable_2, [validator_any])}))
+
+    def validator_list_int(value: list[int]):
+        return value
+
+    assert {"type": "array", "items": {"type": "integer"}} == convert(
+        validator_list_int
+    )
+
+    def validator_list_any(value: list[Any]):
+        return value
+
+    assert {"type": "array", "items": {"type": "string"}} == convert(validator_list_any)
+
+    def validator_list(value: list):
+        return value
+
+    assert {"type": "array", "items": {"type": "string"}} == convert(validator_list)
+
+    def validator_dict(value: dict):
+        return value
+
+    assert {"type": "object", "additionalProperties": True} == convert(validator_dict)
+
+    def validator_dict_int(value: dict[str, int]):
+        return value
+
+    assert {"type": "object", "additionalProperties": {"type": "integer"}} == convert(
+        validator_dict_int
+    )

--- a/voluptuous_openapi/__init__.py
+++ b/voluptuous_openapi/__init__.py
@@ -205,7 +205,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
     if schema in TYPES_MAP:
         return {"type": TYPES_MAP[schema]}
 
-    if schema is list:
+    if schema is list or schema is set:
         return {"type": "array", "items": ensure_default({})}
 
     if schema is dict:
@@ -242,7 +242,7 @@ def convert(schema: Any, *, custom_serializer: Callable | None = None) -> dict:
                         schema, custom_serializer=custom_serializer
                     ),
                 }
-        if get_origin(schema) is list:
+        if get_origin(schema) is list or get_origin(schema) is set:
             schema = [get_args(schema)[0]]
 
         return convert(schema, custom_serializer=custom_serializer)


### PR DESCRIPTION
Add support for validator functions.
Use the function annotations to determine the schema.
Fallback to `{"type": "string"}` if unable to.